### PR TITLE
remove user since pip will not be installed as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8.5-slim-buster
 MAINTAINER Gengo Dev Team
 
+RUN echo 'PATH=/home/python/.local/bin:$PATH' >> .bashrc
 RUN apt-get -y update && apt-get -y install build-essential
 
 WORKDIR /srv

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,8 @@ ARG uid=1000
 
 RUN apt-get -y update && apt-get -y install build-essential
 
-RUN pip install --upgrade pip
-
-RUN adduser -u ${uid} --disabled-password --disabled-login --gecos python python
-USER python
-
 WORKDIR /srv
 COPY . /srv
 
-RUN pip install --no-warn-script-location -r requirements.txt
+RUN pip install -r requirements.txt
 ENTRYPOINT ["/bin/sh", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3.8.5-slim-buster
 MAINTAINER Gengo Dev Team
 
-ARG uid=1000
-
 RUN apt-get -y update && apt-get -y install build-essential
 
 WORKDIR /srv


### PR DESCRIPTION
## Description
As a result of having User on the python.
The python will no longer be installed as Root.
You then need to specify the /home/python/bin/aws to execute awscli rather than directly calling aws command

